### PR TITLE
8 stat viewing

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -74,8 +74,8 @@ processResources {
 
 task testLocal() {
     onlyIf = { true }
-//    dependsOn ":build"
-//    mustRunAfter ":build"
+    dependsOn ":RPG-Framework:build"
+    mustRunAfter ":RPG-Framework:build"
     doLast {
         exec {
             ignoreExitValue = true
@@ -86,8 +86,8 @@ task testLocal() {
 
 task publishServer() {
     onlyIf = { true }
-//    dependsOn "RPG-Framework:plugin:build"
-//    mustRunAfter "RPG-Framework:plugin:build"
+    dependsOn ":RPG-Framework:build"
+    mustRunAfter ":RPG-Framework:build"
     doLast {
         exec {
             ignoreExitValue = true

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id("io.freefair.lombok") version "8.12.1"
+    id("io.freefair.lombok") version "9.5.0"
 }
 
 group = 'io.github.math0898'

--- a/plugin/src/main/java/io/github/math0898/rpgframework/DataManager.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/DataManager.java
@@ -76,6 +76,8 @@ public class DataManager {
                 long experiencePoints = yaml.getLong("experience", 0);
                 long healthTalentPoints = yaml.getLong("talents.health", 0);
                 long damageTalentPoints = yaml.getLong("talents.damage", 0);
+                long movementSpeedTalentPoints = yaml.getLong("talents.speed", 0);
+                long criticalChanceTalentPoints = yaml.getLong("talents.crit_chance", 0);
                 console("File version: " + version);
                 console("Class: " + classString);
                 console("Experience: " + experiencePoints);
@@ -84,6 +86,8 @@ public class DataManager {
                 console("Talents: ");
                 console("Health: " + healthTalentPoints);
                 console("Damage: " + damageTalentPoints);
+                console("Speed: " + movementSpeedTalentPoints);
+                console("Crit Chance: " + criticalChanceTalentPoints);
                 console("Artifacts: ");
                 for (String s : collectedArtifacts)
                     console(" > " + s);
@@ -93,6 +97,8 @@ public class DataManager {
                 rpgPlayer.setExperience(experiencePoints);
                 rpgPlayer.setDamageTalentPoints(damageTalentPoints);
                 rpgPlayer.setHealthTalentPoints(healthTalentPoints);
+                rpgPlayer.setMovementSpeedTalentPoints(movementSpeedTalentPoints);
+                rpgPlayer.setCritChanceTalentPoints(criticalChanceTalentPoints);
                 console("Loaded.", ChatColor.GREEN);
             } catch (Exception exception) {
                 console("Failed to load data for " + player.getName() + ": " + exception.getMessage());
@@ -119,9 +125,13 @@ public class DataManager {
         toSave.set("experience", xp);
         console("Talents: ");
         console("Health: " + player.getHealthTalentPoints());
-        toSave.set("talents.health", player.getHealthTalentPoints());
         console("Damage: " + player.getDamageTalentPoints());
+        console("Speed: " + player.getMovementSpeedTalentPoints());
+        console("Crit Chance: " + player.getCritChanceTalentPoints());
+        toSave.set("talents.health", player.getHealthTalentPoints());
         toSave.set("talents.damage", player.getDamageTalentPoints());
+        toSave.set("talents.speed", player.getMovementSpeedTalentPoints());
+        toSave.set("talents.crit_chance", player.getCritChanceTalentPoints());
         List<String> collectedArtifacts = player.getArtifactCollection();
         console("Artifacts: ");
         for (String s : collectedArtifacts)

--- a/plugin/src/main/java/io/github/math0898/rpgframework/DataManager.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/DataManager.java
@@ -74,12 +74,16 @@ public class DataManager {
                 String version = yaml.getString("version");
                 String classString = yaml.getString("class", "NONE");
                 long experiencePoints = yaml.getLong("experience", 0);
+                long healthTalentPoints = yaml.getLong("talents.health", 0);
+                long damageTalentPoints = yaml.getLong("talents.damage", 0);
                 console("File version: " + version);
                 console("Class: " + classString);
                 console("Experience: " + experiencePoints);
-                // todo: This should use the new RpgPlayer objects.
                 PlayerManager.getPlayer(player.getUuid()).joinClass(Classes.fromString(classString));
                 List<String> collectedArtifacts = yaml.getStringList("artifacts");
+                console("Talents: ");
+                console("Health: " + healthTalentPoints);
+                console("Damage: " + damageTalentPoints);
                 console("Artifacts: ");
                 for (String s : collectedArtifacts)
                     console(" > " + s);
@@ -87,6 +91,8 @@ public class DataManager {
                 RpgPlayer rpgPlayer = PlayerManager.getPlayer(player.getUuid());
                 rpgPlayer.joinClass(Classes.fromString(classString));
                 rpgPlayer.setExperience(experiencePoints);
+                rpgPlayer.setDamageTalentPoints(damageTalentPoints);
+                rpgPlayer.setHealthTalentPoints(healthTalentPoints);
                 console("Loaded.", ChatColor.GREEN);
             } catch (Exception exception) {
                 console("Failed to load data for " + player.getName() + ": " + exception.getMessage());
@@ -105,13 +111,17 @@ public class DataManager {
         YamlConfiguration toSave = new YamlConfiguration();
         console("Version: 2.1");
         toSave.set("version", "2.1");
-        // todo: Use new RpgPlayer object.
         String classString = PlayerManager.getPlayer(player.getUuid()).getCombatClass().toString();
         console("Class: " + classString);
         toSave.set("class", classString);
         long xp = PlayerManager.getPlayer(player.getUuid()).getExperience();
         console("Experience: " + xp);
         toSave.set("experience", xp);
+        console("Talents: ");
+        console("Health: " + player.getHealthTalentPoints());
+        toSave.set("talents.health", player.getHealthTalentPoints());
+        console("Damage: " + player.getDamageTalentPoints());
+        toSave.set("talents.damage", player.getDamageTalentPoints());
         List<String> collectedArtifacts = player.getArtifactCollection();
         console("Artifacts: ");
         for (String s : collectedArtifacts)

--- a/plugin/src/main/java/io/github/math0898/rpgframework/RPGFramework.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/RPGFramework.java
@@ -1,6 +1,7 @@
 package io.github.math0898.rpgframework;
 
 import io.github.math0898.rpgframework.commands.*;
+import io.github.math0898.rpgframework.commands.stats.StatsCommand;
 import io.github.math0898.rpgframework.damage.AdvancedDamageHandler;
 import io.github.math0898.rpgframework.enemies.MobManager;
 import io.github.math0898.rpgframework.hooks.HookManager;
@@ -128,6 +129,7 @@ public final class RPGFramework extends JavaPlugin implements Listener {
         new Classes();
         new SummonRPG();
         new GiveCommand();
+        new StatsCommand();
         new PartyCommand();
         new DebugCommand();
         new EditorCommand();

--- a/plugin/src/main/java/io/github/math0898/rpgframework/RPGFramework.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/RPGFramework.java
@@ -134,6 +134,7 @@ public final class RPGFramework extends JavaPlugin implements Listener {
         new DebugCommand();
         new EditorCommand();
         new ArtifactCommand();
+        new DungeonCreateCommand();
         console("Commands registered.", ChatColor.GREEN);
     }
 }

--- a/plugin/src/main/java/io/github/math0898/rpgframework/RpgPlayer.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/RpgPlayer.java
@@ -358,7 +358,7 @@ public class RpgPlayer {
      * Gets a gear score for this player.
      *
      * @return The player's current gear score.
-     */
+     */ // todo: Consider RPGItem stats.
     public int getGearScore () {
         int runningScore = 0;
         ItemStack[] collection = getBukkitPlayer().getInventory().getArmorContents();
@@ -391,7 +391,7 @@ public class RpgPlayer {
     public ChatColor getPlayerRarity () {
         int gearScore = getGearScore();
 
-        if (gearScore <= 100) return ChatColor.WHITE;
+        if (gearScore <= 100) return ChatColor.WHITE; // todo: Utilize Rarity hex colors.
         else if (gearScore <= 200) return ChatColor.GREEN;
         else if (gearScore <= 300) return ChatColor.BLUE;
         else if (gearScore <= 400) return ChatColor.GOLD;
@@ -411,6 +411,15 @@ public class RpgPlayer {
             } catch (IllegalArgumentException ignored) { }
         }
         player.getInventory().clear();
+    }
+
+    /**
+     * Accessor method for this player's current health.
+     *
+     * @return This player's health.
+     */
+    public double getCurrentHealth () {
+        return getBukkitPlayer().getHealth();
     }
 
     /**

--- a/plugin/src/main/java/io/github/math0898/rpgframework/RpgPlayer.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/RpgPlayer.java
@@ -173,17 +173,21 @@ public class RpgPlayer {
      * The number of talent points spent on increasing max health.
      * -- GETTER --
      * Gets the number of points that this player has put into health.
+     * -- SETTER --
+     * Sets the number of health talent points allocated.
      */
-    @Getter
-    private long healthTalentPoints = 0; // todo: Persist restarts
+    @Getter @Setter
+    private long healthTalentPoints = 0;
 
     /**
      * The number of talent points spent on increasing base damage.
      * -- GETTER --
      * Gets the number of points that this player has put into damage.
+     * -- SETTER --
+     * Sets the number of damage talent points allocated.
      */
-    @Getter
-    private long damageTalentPoints = 0; // todo: Persist restarts
+    @Getter @Setter
+    private long damageTalentPoints = 0;
 
     /**
      * Default constructor for an RpgPlayer object. Caches the given Player object and grabs the name and UUID.
@@ -495,6 +499,18 @@ public class RpgPlayer {
         else if (current / max < 0.50) prefix = ChatColor.RED;
 
         return prefix + "" + current;
+    }
+
+    /**
+     * Accessor method for the player's current damage. This is heavily influenced by equipment. This is the scaled down
+     * damage value.
+     *
+     * @return This player's damage.
+     */
+    public double getCurrentDamage () {
+        AttributeInstance instance = bukkitPlayer.getAttribute(Attribute.GENERIC_ATTACK_DAMAGE);
+        if (instance == null) return 0;
+        return instance.getValue();
     }
 
     /**

--- a/plugin/src/main/java/io/github/math0898/rpgframework/RpgPlayer.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/RpgPlayer.java
@@ -64,6 +64,26 @@ public class RpgPlayer {
     public static final double DAMAGE_PER_POINT = 1; // todo: Configurable because of balance. Ideally during runtime.
 
     /**
+     * The amount of critical strike chance given to a player per talent point spent.
+     */
+    public static final double CRIT_CHANCE_PER_POINT = 0.025; // todo: Configurable because of balance. Ideally during runtime.
+
+    /**
+     * The maximum number of points that can be spent on critical strike chance.
+     */
+    public static final long CRIT_CHANCE_MAX_POINTS = 40; // todo: Configurable because of balance. Ideally during runtime.
+
+    /**
+     * The amount of movement speed given to a player per point spent.
+     */
+    public static final double MOVEMENT_SPEED_PER_POINT = 0.03; // todo: Configurable because of balance. Ideally during runtime.
+
+    /**
+     * The maximum number of points that can be spent on movement speed.
+     */
+    public static final long MOVEMENT_SPEED_MAX_POINTS = 10; // todo: Configurable because of balance. Ideally during runtime.
+
+    /**
      * A list of artifacts that have been collected by this player.
      * -- GETTER --
      *  Accessor method for the artifact collection of this player.
@@ -190,6 +210,26 @@ public class RpgPlayer {
     private long damageTalentPoints = 0;
 
     /**
+     * The chance that any strike could be a critical strike and deal double damage.
+     * -- GETTER --
+     * Gets the number of points allocated to critical strike chance.
+     * -- SETTER --
+     * Sets the number of points allocated to critical strike chance.
+     */
+    @Getter @Setter
+    private long critChanceTalentPoints = 0;
+
+    /**
+     * The amount of talent points that have been spent on increased movement speed.
+     * -- GETTER --
+     * Gets the number of points spent on moving faster.
+     * -- SETTER --
+     * Sets the number of points allocated to movement speed.
+     */
+    @Getter @Setter
+    private long movementSpeedTalentPoints = 0;
+
+    /**
      * Default constructor for an RpgPlayer object. Caches the given Player object and grabs the name and UUID.
      *
      * @param p The player this construct points to.
@@ -199,6 +239,7 @@ public class RpgPlayer {
         this.bukkitPlayer = p;
         this.name = p.getName();
         refresh();
+        Bukkit.getScheduler().runTaskLater(Utils.getPlugin(), this::refresh, 3 * 20);
     }
 
     /**
@@ -286,7 +327,12 @@ public class RpgPlayer {
      * @return The number of upgrade points available.
      */
     public int getPointsUnallocated () {
-        return (int) ((getLevel() - healthTalentPoints) - damageTalentPoints);
+        long total_points = getLevel();
+        total_points -= healthTalentPoints;
+        total_points -= damageTalentPoints;
+        total_points -= movementSpeedTalentPoints;
+        total_points -= critChanceTalentPoints;
+        return (int) total_points;
     }
 
     /**
@@ -304,10 +350,23 @@ public class RpgPlayer {
         if (field.equalsIgnoreCase("health")) {
             healthTalentPoints++;
             sendMessage(ChatColor.GREEN + "You feel healthier now! " + StringUtils.convertHexCodes("#F454DA") + "+" + HEALTH_PER_POINT + " Health");
-        }
-        else if (field.equalsIgnoreCase("damage")) {
+        } else if (field.equalsIgnoreCase("damage")) {
             damageTalentPoints++;
             sendMessage(ChatColor.GREEN + "Your attacks hit harder! " + StringUtils.convertHexCodes("#D93747") + "+" + DAMAGE_PER_POINT + " Damage");
+        } else if (field.equalsIgnoreCase("movement_speed")) {
+            if (movementSpeedTalentPoints == MOVEMENT_SPEED_MAX_POINTS) {
+                sendMessage(ChatColor.RED + "You've reached the maximum level!");
+                return;
+            }
+            movementSpeedTalentPoints++;
+            sendMessage(ChatColor.GREEN + "You move faster! " + ChatColor.AQUA + "+" + (100 * MOVEMENT_SPEED_PER_POINT) + " Speed");
+        } else if (field.equalsIgnoreCase("critical_chance")) {
+            if (critChanceTalentPoints == CRIT_CHANCE_MAX_POINTS) {
+                sendMessage(ChatColor.RED + "You've reached the maximum level!");
+                return;
+            }
+            critChanceTalentPoints++;
+            sendMessage(ChatColor.GREEN + "Your strikes find more weak-spots! " + ChatColor.YELLOW + "+" + (CRIT_CHANCE_PER_POINT * 100) + " Critical Strike Chance");
         }
 
         refresh();
@@ -319,6 +378,8 @@ public class RpgPlayer {
     public void resetPoints () {
         healthTalentPoints = 0;
         damageTalentPoints = 0;
+        movementSpeedTalentPoints = 0;
+        critChanceTalentPoints = 0;
         sendMessage(ChatColor.GREEN + "You've reset all your base talent points.");
         refresh();
     }
@@ -391,12 +452,12 @@ public class RpgPlayer {
         }
         final double RPG_TO_MC_SCALAR = 5.0; // Scales RPG health/damage values to Mc attribute ones.
         Player player = getBukkitPlayer();
-        // Every level except lvl 1, and lvls ending in 5/10.
         AttributeModifier healthMod = new AttributeModifier(new UUID(100, 234), "", healthBonus() / RPG_TO_MC_SCALAR, AttributeModifier.Operation.ADD_NUMBER);
-        // Every level that ends in 5/10.
         AttributeModifier damageMod = new AttributeModifier(new UUID(100, 235), "", damageBonus() / RPG_TO_MC_SCALAR, AttributeModifier.Operation.ADD_NUMBER);
+        AttributeModifier speedMod = new AttributeModifier(new UUID(100, 236), "", getMovementSpeedTalentPoints() * MOVEMENT_SPEED_PER_POINT, AttributeModifier.Operation.ADD_NUMBER);
         AttributeInstance healthInstance = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
         AttributeInstance damageInstance = player.getAttribute(Attribute.GENERIC_ATTACK_DAMAGE);
+        AttributeInstance speedInstance = player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
         if (healthInstance != null) {
             Collection<AttributeModifier> modifiers = healthInstance.getModifiers();
             if (!modifiers.isEmpty())
@@ -407,6 +468,7 @@ public class RpgPlayer {
         } else {
             RPGFramework.console("Attempted to update " + player.getName() + "'s health but GENERIC_MAX_HEALTH instance is null.", ChatColor.RED);
         }
+        // todo: Abstract damage and speed.
         if (damageInstance != null) {
             Collection<AttributeModifier> modifiers = damageInstance.getModifiers();
             if (!modifiers.isEmpty())
@@ -414,6 +476,14 @@ public class RpgPlayer {
             damageInstance.addModifier(damageMod);
         } else {
             RPGFramework.console("Attempted to update " + player.getName() + "'s damage but GENERIC_ATTACK_DAMAGE instance is null.", ChatColor.RED);
+        }
+        if (speedInstance != null) {
+            Collection<AttributeModifier> modifiers = speedInstance.getModifiers();
+            if (!modifiers.isEmpty())
+                speedInstance.removeModifier(speedMod);
+            speedInstance.addModifier(speedMod);
+        } else {
+            RPGFramework.console("Attempted to update " + player.getName() + "'s damage but GENERIC_MOVEMENT_SPEED instance is null.", ChatColor.RED);
         }
     }
 
@@ -593,6 +663,9 @@ public class RpgPlayer {
         fighting = System.currentTimeMillis();
         enteringCombat();
         classObject.attack(event);
+        // todo: Move this elsewhere, using AdvancedDamageEvent.
+        double roll = new Random().nextDouble();
+        if (roll < critChanceTalentPoints * CRIT_CHANCE_PER_POINT) event.setDamage(event.getDamage() * 2.0);
         lastHitBy = event.getEntity();
     }
 

--- a/plugin/src/main/java/io/github/math0898/rpgframework/RpgPlayer.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/RpgPlayer.java
@@ -56,12 +56,12 @@ public class RpgPlayer {
     /**
      * The amount of health granted per talent point spent on maximum health.
      */
-    private static final double HEALTH_PER_POINT = 5;
+    public static final double HEALTH_PER_POINT = 5; // todo: Configurable because of balance. Ideally during runtime.
 
     /**
      * The amount of base damage granted per talent point spent on damage.
      */
-    private static final double DAMAGE_PER_POINT = 1;
+    public static final double DAMAGE_PER_POINT = 1; // todo: Configurable because of balance. Ideally during runtime.
 
     /**
      * A list of artifacts that have been collected by this player.
@@ -273,7 +273,16 @@ public class RpgPlayer {
         refresh();
         getBukkitPlayer().playSound(getBukkitPlayer(), Sound.UI_TOAST_CHALLENGE_COMPLETE, 0.5f, 1.0f);
         sendMessage(ChatColor.GREEN + "You've leveled up! Level: " + getLevel());
-        sendMessage(ChatColor.DARK_AQUA + "You have " + ((getLevel() - healthTalentPoints) - damageTalentPoints) + " unspent points!");
+        sendMessage(ChatColor.DARK_AQUA + "You have " + getPointsUnallocated() + " unspent points!");
+    }
+
+    /**
+     * Gets the total number of available points for this RpgPlayer.
+     *
+     * @return The number of upgrade points available.
+     */
+    public int getPointsUnallocated () {
+        return (int) ((getLevel() - healthTalentPoints) - damageTalentPoints);
     }
 
     /**
@@ -283,7 +292,7 @@ public class RpgPlayer {
      */
     public void allocatePoint (String field) {
 
-        if (getLevel() < healthTalentPoints + damageTalentPoints + 1) {
+        if (getPointsUnallocated() <= 0) {
             sendMessage(ChatColor.RED + "You do not have enough points to do that!");
             return;
         }

--- a/plugin/src/main/java/io/github/math0898/rpgframework/RpgPlayer.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/RpgPlayer.java
@@ -82,7 +82,8 @@ public class RpgPlayer {
      * The maximum number of points that can be spent on movement speed.
      */
     public static final long MOVEMENT_SPEED_MAX_POINTS = 10; // todo: Configurable because of balance. Ideally during runtime.
-
+    // todo: loot drop rate
+    //      critical damage
     /**
      * A list of artifacts that have been collected by this player.
      * -- GETTER --

--- a/plugin/src/main/java/io/github/math0898/rpgframework/RpgPlayer.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/RpgPlayer.java
@@ -175,7 +175,7 @@ public class RpgPlayer {
      * Gets the number of points that this player has put into health.
      */
     @Getter
-    private long healthTalentPoints = 0;
+    private long healthTalentPoints = 0; // todo: Persist restarts
 
     /**
      * The number of talent points spent on increasing base damage.
@@ -183,7 +183,7 @@ public class RpgPlayer {
      * Gets the number of points that this player has put into damage.
      */
     @Getter
-    private long damageTalentPoints = 0;
+    private long damageTalentPoints = 0; // todo: Persist restarts
 
     /**
      * Default constructor for an RpgPlayer object. Caches the given Player object and grabs the name and UUID.
@@ -290,11 +290,11 @@ public class RpgPlayer {
 
         if (field.equalsIgnoreCase("health")) {
             healthTalentPoints++;
-            sendMessage(ChatColor.GREEN + "You feel healthier now! +" + StringUtils.convertHexCodes("#F454DA") + HEALTH_PER_POINT + " Health");
+            sendMessage(ChatColor.GREEN + "You feel healthier now! " + StringUtils.convertHexCodes("#F454DA") + "+" + HEALTH_PER_POINT + " Health");
         }
         else if (field.equalsIgnoreCase("damage")) {
             damageTalentPoints++;
-            sendMessage(ChatColor.GREEN + "Your attacks hit harder! +" + StringUtils.convertHexCodes("#D93747") + DAMAGE_PER_POINT + " Damage");
+            sendMessage(ChatColor.GREEN + "Your attacks hit harder! " + StringUtils.convertHexCodes("#D93747") + "+" + DAMAGE_PER_POINT + " Damage");
         }
 
         refresh();

--- a/plugin/src/main/java/io/github/math0898/rpgframework/RpgPlayer.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/RpgPlayer.java
@@ -54,6 +54,16 @@ public class RpgPlayer {
     private static final long TIME_UNTIL_OUT_OF_COMBAT = 10000;
 
     /**
+     * The amount of health granted per talent point spent on maximum health.
+     */
+    private static final double HEALTH_PER_POINT = 5;
+
+    /**
+     * The amount of base damage granted per talent point spent on damage.
+     */
+    private static final double DAMAGE_PER_POINT = 1;
+
+    /**
      * A list of artifacts that have been collected by this player.
      * -- GETTER --
      *  Accessor method for the artifact collection of this player.
@@ -75,9 +85,6 @@ public class RpgPlayer {
      * The Entity that last successfully hit this player.
      * -- GETTER --
      *  An accessor method to get the last Entity that attacked this Player.
-     *
-     * @return The entity that last attacked the Player.
-
      */
     @Getter
     private Entity lastHitBy = null;
@@ -161,6 +168,22 @@ public class RpgPlayer {
      */
     @Getter
     private final String name;
+
+    /**
+     * The number of talent points spent on increasing max health.
+     * -- GETTER --
+     * Gets the number of points that this player has put into health.
+     */
+    @Getter
+    private long healthTalentPoints = 0;
+
+    /**
+     * The number of talent points spent on increasing base damage.
+     * -- GETTER --
+     * Gets the number of points that this player has put into damage.
+     */
+    @Getter
+    private long damageTalentPoints = 0;
 
     /**
      * Default constructor for an RpgPlayer object. Caches the given Player object and grabs the name and UUID.
@@ -250,32 +273,59 @@ public class RpgPlayer {
         refresh();
         getBukkitPlayer().playSound(getBukkitPlayer(), Sound.UI_TOAST_CHALLENGE_COMPLETE, 0.5f, 1.0f);
         sendMessage(ChatColor.GREEN + "You've leveled up! Level: " + getLevel());
-        if (level % 5 != 0)
-            sendMessage(StringUtils.convertHexCodes("#F454DA") + " +5 Health");
-        else
-            sendMessage(StringUtils.convertHexCodes("#D93747") + " +1 Damage");
+        sendMessage(ChatColor.DARK_AQUA + "You have " + ((getLevel() - healthTalentPoints) - damageTalentPoints) + " unspent points!");
     }
 
     /**
-     * Determines how much of a health bonus a player of the given level should have. These are RPG numbers that are
-     * then scaled down.
+     * Attempts to allocate an additional point to health.
      *
-     * @param level The player's current level.
+     * @param field The field to allocate a talent point to.
+     */
+    public void allocatePoint (String field) {
+
+        if (getLevel() < healthTalentPoints + damageTalentPoints + 1) {
+            sendMessage(ChatColor.RED + "You do not have enough points to do that!");
+            return;
+        }
+
+        if (field.equalsIgnoreCase("health")) {
+            healthTalentPoints++;
+            sendMessage(ChatColor.GREEN + "You feel healthier now! +" + StringUtils.convertHexCodes("#F454DA") + HEALTH_PER_POINT + " Health");
+        }
+        else if (field.equalsIgnoreCase("damage")) {
+            damageTalentPoints++;
+            sendMessage(ChatColor.GREEN + "Your attacks hit harder! +" + StringUtils.convertHexCodes("#D93747") + DAMAGE_PER_POINT + " Damage");
+        }
+
+        refresh();
+    }
+
+    /**
+     * Resets any point allocations that this player has made.
+     */
+    public void resetPoints () {
+        healthTalentPoints = 0;
+        damageTalentPoints = 0;
+        sendMessage(ChatColor.GREEN + "You've reset all your base talent points.");
+        refresh();
+    }
+
+    /**
+     * Determines how much of a health bonus this player should have. These are RPG numbers that are then scaled down.
+     *
      * @return The bonus health that should be added onto the player's health.
      */
-    private static double healthBonus (long level) {
-        return ((level - 1) - (level / 5.0)) * 5;
+    private double healthBonus () {
+        return healthTalentPoints * HEALTH_PER_POINT;
     }
 
     /**
-     * Determines how much of a damage bonus a player of the given level should have. These are RPG numbers that are
-     * then scaled down.
+     * Determines how much of a damage bonus this player should have. These are RPG numbers that are then scaled down.
      *
-     * @param level The player's current level.
      * @return The bonus damage that should be added onto the player's attacks.
      */
-    private static double damageBonus (long level) {
-        return level / 5;
+    private double damageBonus () {
+        return damageTalentPoints * DAMAGE_PER_POINT;
     }
 
     /**
@@ -329,9 +379,9 @@ public class RpgPlayer {
         final double RPG_TO_MC_SCALAR = 5.0; // Scales RPG health/damage values to Mc attribute ones.
         Player player = getBukkitPlayer();
         // Every level except lvl 1, and lvls ending in 5/10.
-        AttributeModifier healthMod = new AttributeModifier(new UUID(100, 234), "", healthBonus(getLevel()) / RPG_TO_MC_SCALAR, AttributeModifier.Operation.ADD_NUMBER);
+        AttributeModifier healthMod = new AttributeModifier(new UUID(100, 234), "", healthBonus() / RPG_TO_MC_SCALAR, AttributeModifier.Operation.ADD_NUMBER);
         // Every level that ends in 5/10.
-        AttributeModifier damageMod = new AttributeModifier(new UUID(100, 235), "", damageBonus(getLevel()) / RPG_TO_MC_SCALAR, AttributeModifier.Operation.ADD_NUMBER);
+        AttributeModifier damageMod = new AttributeModifier(new UUID(100, 235), "", damageBonus() / RPG_TO_MC_SCALAR, AttributeModifier.Operation.ADD_NUMBER);
         AttributeInstance healthInstance = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
         AttributeInstance damageInstance = player.getAttribute(Attribute.GENERIC_ATTACK_DAMAGE);
         if (healthInstance != null) {

--- a/plugin/src/main/java/io/github/math0898/rpgframework/commands/DungeonCreateCommand.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/commands/DungeonCreateCommand.java
@@ -1,0 +1,124 @@
+package io.github.math0898.rpgframework.commands;
+
+import io.github.math0898.utils.Utils;
+import io.github.math0898.utils.commands.BetterCommand;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.io.FileWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * The dungeon create command is used to export regions of a Minecraft server into a yaml format that defines tiles in
+ * dungeons.
+ * // TODO: More user friendly please.
+ * @author Sugaku
+ */
+public class DungeonCreateCommand extends BetterCommand {
+
+    /**
+     * Creates a new BetterCommand with the given name.
+     */
+    public DungeonCreateCommand () {
+        super("rpg-dungo");
+    }
+
+    /**
+     * Attempts to export the given region in a YAML format for use with dungeons.
+     *
+     * @param locale The first corner location.
+     * @param locale2 The second corner location.
+     */
+    private void exportDelegate (Location locale, Location locale2) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Unnamed:\n");
+        // todo
+//        builder.append("  footprint:\n");
+//        builder.append("    corner1:\n");
+//        builder.append("");
+        AtomicInteger num = new AtomicInteger();
+        Map<Material, List<String>> blocks = new HashMap<>();
+        for (int i = locale.getBlockX(); i < locale2.getBlockX(); i++)
+            for (int j = locale.getBlockY(); j < locale2.getBlockY(); j++)
+                for (int k = locale.getBlockZ(); k < locale2.getBlockZ(); k++) {
+                    Material key = locale.getWorld().getType(i, j, k);
+                    if (key.isAir()) continue;
+                    if (!blocks.containsKey(key))
+                        blocks.put(key, new ArrayList<>());
+                    blocks.get(key).add("      " + num.getAndIncrement() + ":\n        x: " + (i - locale.getBlockX()) +
+                            "\n        y: " + (j - locale.getBlockY()) +
+                            "\n        z: " + (k - locale.getBlockZ()) + "\n");
+                }
+        blocks.forEach((m, list) -> {
+            builder.append("    " + m + ": \n");
+            for (String s : list)
+                builder.append(s);
+        });
+        try (FileWriter writer = new FileWriter("./exportZone.yaml")) {
+            writer.write(builder.toString());
+        } catch (Exception ignored) { }
+        send(Bukkit.getConsoleSender(), "Finished zone export.");
+    }
+
+    /**
+     * Called whenever specifically a player executes this command.
+     *
+     * @param player The player who ran this command.
+     * @param args   The arguments they passed to the command.
+     */
+    @Override
+    public boolean onPlayerCommand (Player player, String[] args) {
+        // /rpg-dungo -570 65 -490 -520 70 -490
+        if (args.length < 6) send(player, ChatColor.RED + "Not enough args.");
+        final Location l1 = new Location(player.getWorld(),
+                Math.min(getIntegerParam(0, args, player), getIntegerParam(3, args, player)),
+                Math.min(getIntegerParam(1, args, player), getIntegerParam(4, args, player)),
+                Math.min(getIntegerParam(2, args, player), getIntegerParam(5, args, player)));
+        final Location l2 = new Location(player.getWorld(),
+                Math.max(getIntegerParam(0, args, player), getIntegerParam(3, args, player)),
+                Math.max(getIntegerParam(1, args, player), getIntegerParam(4, args, player)),
+                Math.max(getIntegerParam(2, args, player), getIntegerParam(5, args, player)));
+        Bukkit.getScheduler().runTaskAsynchronously(Utils.getPlugin(), () -> exportDelegate(l1, l2));
+        send(player, ChatColor.GREEN + "Starting zone export.");
+        return true;
+    }
+
+    /**
+     * Called whenever an unspecified sender executes this command. This could include console and command blocks.
+     *
+     * @param sender The sender who ran this command.
+     * @param args   The arguments they passed to the command.
+     */
+    @Override
+    public boolean onNonPlayerCommand (CommandSender sender, String[] args) {
+        send(sender, ChatColor.RED + "This command must be ran as a player.");
+        return true;
+    }
+
+    /**
+     * Called whenever a command sender is trying to tab complete a command.
+     *
+     * @param sender The sender who is tab completing this command.
+     * @param args   The current arguments they have typed.
+     */
+    @Override
+    public List<String> simplifiedTab (CommandSender sender, String[] args) {
+        return switch (args.length) {
+            case 1 -> List.of("<x1>");
+            case 2 -> List.of("<y1>");
+            case 3 -> List.of("<z1>");
+            case 4 -> List.of("<x2>");
+            case 5 -> List.of("<y2>");
+            case 6 -> List.of("<z2>");
+            default -> List.of();
+        };
+    }
+}

--- a/plugin/src/main/java/io/github/math0898/rpgframework/commands/stats/StatsCommand.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/commands/stats/StatsCommand.java
@@ -57,7 +57,7 @@ public class StatsCommand extends BetterCommand {
      */
     @Override
     public List<String> simplifiedTab (CommandSender sender, String[] args) {
-        if (args.length >= 1) // todo: Requires validation.
+        if (args.length == 1) // todo: Requires validation.
             return everythingStartsWith(getPlayerList(), args[args.length - 1]);
         return List.of();
     }

--- a/plugin/src/main/java/io/github/math0898/rpgframework/commands/stats/StatsCommand.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/commands/stats/StatsCommand.java
@@ -1,0 +1,64 @@
+package io.github.math0898.rpgframework.commands.stats;
+
+import io.github.math0898.utils.commands.BetterCommand;
+import io.github.math0898.utils.gui.GUIManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+
+/**
+ * The stats command is used to view player stats such as boss kills, xp, strength, health, etc. Can also be utilized to
+ * view other player stats.
+ *
+ * @author Sugaku
+ */
+public class StatsCommand extends BetterCommand {
+
+    /**
+     * Creates a new BetterCommand with the given name and prefix.
+     */
+    public StatsCommand () {
+        super("stats", ChatColor.DARK_GRAY + "[" + ChatColor.DARK_GREEN + "RPG" + ChatColor.DARK_GRAY + "] ");
+        GUIManager.getInstance().addGUI("stats-gui", new StatsGUI());
+    }
+
+    /**
+     * Called whenever specifically a player executes this command.
+     *
+     * @param player The player who ran this command.
+     * @param args   The arguments they passed to the command.
+     */
+    @Override
+    public boolean onPlayerCommand (Player player, String[] args) {
+        if (args.length == 0) GUIManager.getInstance().openGUI("stats-gui", player);
+        else GUIManager.getInstance().openGUI("stats-gui", player, args);
+        return true;
+    }
+
+    /**
+     * Called whenever an unspecified sender executes this command. This could include console and command blocks.
+     *
+     * @param sender The sender who ran this command.
+     * @param args   The arguments they passed to the command.
+     */
+    @Override
+    public boolean onNonPlayerCommand (CommandSender sender, String[] args) {
+        send(sender, ChatColor.RED + "This command can only be ran as a player.");
+        return true;
+    }
+
+    /**
+     * Called whenever a command sender is trying to tab complete a command.
+     *
+     * @param sender The sender who is tab completing this command.
+     * @param args   The current arguments they have typed.
+     */
+    @Override
+    public List<String> simplifiedTab (CommandSender sender, String[] args) {
+        if (args.length >= 1) // todo: Requires validation.
+            return everythingStartsWith(getPlayerList(), args[args.length - 1]);
+        return List.of();
+    }
+}

--- a/plugin/src/main/java/io/github/math0898/rpgframework/commands/stats/StatsGUI.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/commands/stats/StatsGUI.java
@@ -1,0 +1,79 @@
+package io.github.math0898.rpgframework.commands.stats;
+
+import io.github.math0898.rpgframework.PlayerManager;
+import io.github.math0898.rpgframework.RpgPlayer;
+import io.github.math0898.utils.gui.AbstractGUI;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+
+/**
+ * The StatsGUI shows information about a player.
+ *
+ * @author Sugaku
+ */
+public class StatsGUI extends AbstractGUI {
+
+    /**
+     * Opens this GUI to the given player.
+     *
+     * @param player The player to open the GUI to.
+     */
+    @Override
+    public void openInventory (Player player) {
+        openInventory(player, player.getName());
+    }
+
+    /**
+     * Opens this GUI to the given player.
+     *
+     * @param player The player to open the GUI to.
+     * @param params Any parameters to add to the inventory when to open.
+     */
+    @Override
+    public void openInventory (Player player, String... params) {
+        if (params.length < 1) return; // No player provided.
+        openInventory(player, PlayerManager.getPlayer(params[0]));
+    }
+
+    /**
+     * Opens this GUI to the given player.
+     *
+     * @param player The player to open the GUI to.
+     * @param rpgPlayer The RpgPlayer to open stats on and about.
+     */
+    public void openInventory (Player player, RpgPlayer rpgPlayer) {
+        if (rpgPlayer == null) return;
+        // todo: implement.
+    }
+
+    /**
+     * Called whenever this GUI is clicked.
+     *
+     * @param event The inventory click event.
+     */
+    @Override
+    public void onClick (InventoryClickEvent event) {
+        event.setCancelled(true);
+    }
+
+    /**
+     * Called whenever this GUI is closed.
+     *
+     * @param event The inventory close event.
+     */
+    @Override
+    public void onClose (InventoryCloseEvent event) {
+
+    }
+
+    /**
+     * Gets the title of this GUI. Used by the GUIManager to route InventoryClickEvents.
+     *
+     * @return The title of this GUI.
+     */
+    @Override
+    public String getTitle () {
+        return "Player Stats";
+    }
+}

--- a/plugin/src/main/java/io/github/math0898/rpgframework/commands/stats/StatsGUI.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/commands/stats/StatsGUI.java
@@ -3,9 +3,15 @@ package io.github.math0898.rpgframework.commands.stats;
 import io.github.math0898.rpgframework.PlayerManager;
 import io.github.math0898.rpgframework.RpgPlayer;
 import io.github.math0898.utils.gui.AbstractGUI;
+import io.github.math0898.utils.items.ItemBuilder;
+import net.md_5.bungee.api.ChatColor;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
 
 /**
  * The StatsGUI shows information about a player.
@@ -44,7 +50,21 @@ public class StatsGUI extends AbstractGUI {
      */
     public void openInventory (Player player, RpgPlayer rpgPlayer) {
         if (rpgPlayer == null) return;
-        // todo: implement.
+        Inventory inv = Bukkit.createInventory(player, 45, getTitle());
+        ItemStack fill = new ItemBuilder(Material.BLACK_STAINED_GLASS_PANE).setDisplayName(" ").build();
+        for (int i = 0; i < 45; i++)
+            inv.setItem(i, fill);
+        inv.setItem(13, new ItemBuilder(Material.PLAYER_HEAD)
+                .setOwningPlayer(rpgPlayer.getUuid())
+                .setDisplayName(rpgPlayer.getPlayerRarity() + rpgPlayer.getName())
+                .setLore(new String[] { // todo: Make these colors match item colors.
+                        ChatColor.RED + "Health: " + (rpgPlayer.getCurrentHealth() * 5.0) + " / " + (rpgPlayer.getMaxHealth() * 5.0),
+                        ChatColor.DARK_GREEN + "Class: " + rpgPlayer.getCombatClass().getFormattedName(),
+                        ChatColor.AQUA + "Current Level: " + rpgPlayer.getLevel() + " (" + rpgPlayer.getExperience() + ")",
+                        ChatColor.YELLOW + "Gear Score: " + rpgPlayer.getGearScore()
+                }).build());
+        // todo: Boss kill statistics.
+        player.openInventory(inv);
     }
 
     /**

--- a/plugin/src/main/java/io/github/math0898/rpgframework/commands/stats/StatsGUI.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/commands/stats/StatsGUI.java
@@ -54,24 +54,31 @@ public class StatsGUI extends AbstractGUI {
         ItemStack fill = new ItemBuilder(Material.BLACK_STAINED_GLASS_PANE).setDisplayName(" ").build();
         for (int i = 0; i < 45; i++)
             inv.setItem(i, fill);
+        updateActive(inv, player, rpgPlayer);
+        // todo: Boss kill statistics.
+        player.openInventory(inv);
+    }
+
+    /**
+     * Updates the active portion of this StatsGUI. This includes the player's live stat-line as well as talent point
+     * selections.
+     */
+    private void updateActive (Inventory inv, Player viewer, RpgPlayer target) {
         inv.setItem(13, new ItemBuilder(Material.PLAYER_HEAD)
-                .setOwningPlayer(rpgPlayer.getUuid())
-                .setDisplayName(rpgPlayer.getPlayerRarity() + rpgPlayer.getName())
+                .setOwningPlayer(target.getUuid())
+                .setDisplayName(target.getPlayerRarity() + target.getName())
                 .setLore(new String[] { // todo: Make these colors match item colors.
-                        ChatColor.RED + "Health: " + (long) (rpgPlayer.getCurrentHealth() * 5.0) + " / " + (long) (rpgPlayer.getMaxHealth() * 5.0),
-                        ChatColor.DARK_GREEN + "Class: " + rpgPlayer.getCombatClass().getFormattedName(),
-                        ChatColor.AQUA + "Current Level: " + rpgPlayer.getLevel() + " (" + rpgPlayer.getExperience() + ")",
-                        ChatColor.YELLOW + "Gear Score: " + rpgPlayer.getGearScore()
+                        ChatColor.RED + "Health: " + (long) (target.getCurrentHealth() * 5.0) + " / " + (long) (target.getMaxHealth() * 5.0),
+                        ChatColor.DARK_GREEN + "Class: " + target.getCombatClass().getFormattedName(),
+                        ChatColor.AQUA + "Current Level: " + target.getLevel() + " (" + target.getExperience() + ")",
+                        ChatColor.YELLOW + "Gear Score: " + target.getGearScore()
                 }).build());
 
-        if (player.getUniqueId() == rpgPlayer.getUuid()) {
+        if (viewer.getUniqueId() == target.getUuid()) {
             inv.setItem(29, new ItemBuilder(Material.IRON_CHESTPLATE).setDisplayName("Increase Health").build());
             inv.setItem(33, new ItemBuilder(Material.IRON_SWORD).setDisplayName("Increase Damage").build());
             inv.setItem(40, new ItemBuilder(Material.BARRIER).setDisplayName("Reset Points").build());
         }
-
-        // todo: Boss kill statistics.
-        player.openInventory(inv);
     }
 
     /**
@@ -92,7 +99,8 @@ public class StatsGUI extends AbstractGUI {
                 case 33 -> rpgPlayer.allocatePoint("damage");
                 case 40 -> rpgPlayer.resetPoints();
             }
-            // todo: Refresh inventory.
+            // todo: This might cause issues when viewing another player.
+            updateActive(inv, player, rpgPlayer);
         }
     }
 

--- a/plugin/src/main/java/io/github/math0898/rpgframework/commands/stats/StatsGUI.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/commands/stats/StatsGUI.java
@@ -58,11 +58,18 @@ public class StatsGUI extends AbstractGUI {
                 .setOwningPlayer(rpgPlayer.getUuid())
                 .setDisplayName(rpgPlayer.getPlayerRarity() + rpgPlayer.getName())
                 .setLore(new String[] { // todo: Make these colors match item colors.
-                        ChatColor.RED + "Health: " + (rpgPlayer.getCurrentHealth() * 5.0) + " / " + (rpgPlayer.getMaxHealth() * 5.0),
+                        ChatColor.RED + "Health: " + (long) (rpgPlayer.getCurrentHealth() * 5.0) + " / " + (long) (rpgPlayer.getMaxHealth() * 5.0),
                         ChatColor.DARK_GREEN + "Class: " + rpgPlayer.getCombatClass().getFormattedName(),
                         ChatColor.AQUA + "Current Level: " + rpgPlayer.getLevel() + " (" + rpgPlayer.getExperience() + ")",
                         ChatColor.YELLOW + "Gear Score: " + rpgPlayer.getGearScore()
                 }).build());
+
+        if (player.getUniqueId() == rpgPlayer.getUuid()) {
+            inv.setItem(29, new ItemBuilder(Material.IRON_CHESTPLATE).setDisplayName("Increase Health").build());
+            inv.setItem(33, new ItemBuilder(Material.IRON_SWORD).setDisplayName("Increase Damage").build());
+            inv.setItem(40, new ItemBuilder(Material.BARRIER).setDisplayName("Reset Points").build());
+        }
+
         // todo: Boss kill statistics.
         player.openInventory(inv);
     }
@@ -75,6 +82,18 @@ public class StatsGUI extends AbstractGUI {
     @Override
     public void onClick (InventoryClickEvent event) {
         event.setCancelled(true);
+        if (event.getClickedInventory() == null) return;
+        Inventory inv = event.getClickedInventory();
+        if (inv.getHolder() instanceof Player player) {
+            RpgPlayer rpgPlayer = PlayerManager.getPlayer(player.getUniqueId());
+            if (rpgPlayer == null) return;
+            switch (event.getSlot()) { // todo: These should be inactive if player is not the player who's stats are showing.
+                case 29 -> rpgPlayer.allocatePoint("health");
+                case 33 -> rpgPlayer.allocatePoint("damage");
+                case 40 -> rpgPlayer.resetPoints();
+            }
+            // todo: Refresh inventory.
+        }
     }
 
     /**

--- a/plugin/src/main/java/io/github/math0898/rpgframework/commands/stats/StatsGUI.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/commands/stats/StatsGUI.java
@@ -73,6 +73,7 @@ public class StatsGUI extends AbstractGUI {
                 .setDisplayName(target.getPlayerRarity() + target.getName())
                 .setLore(new String[] { // todo: Make these colors match item colors.
                         StringUtils.convertHexCodes("#F454DAHealth: " + (long) (target.getCurrentHealth() * 5.0) + " / " + (long) (target.getMaxHealth() * 5.0)),
+                        StringUtils.convertHexCodes("#D93747Damage: " + (long) (target.getCurrentDamage() * 5.0)),
                         StringUtils.convertHexCodes("#CCCCCCClass: " + target.getCombatClass().getFormattedName()),
                         ChatColor.AQUA + "Current Level: " + target.getLevel() + " (" + target.getExperience() + ")",
                         StringUtils.convertHexCodes("#F2D951Gear Score: " + target.getGearScore())
@@ -84,7 +85,7 @@ public class StatsGUI extends AbstractGUI {
                             StringUtils.convertHexCodes("#CCCCCC" + "Gain health per point spent on tenacity."),
                             StringUtils.convertHexCodes("#CCCCCC" + "Current Bonus:#F454DA +" + target.getHealthTalentPoints() * HEALTH_PER_POINT),
                             StringUtils.convertHexCodes("#CCCCCC" + "Available Points: " + ChatColor.DARK_AQUA + target.getPointsUnallocated())
-                    }).build());
+                    }).build()); // todo: Ascending costs?
             inv.setItem(33, new ItemBuilder(Material.IRON_SWORD).setDisplayName(StringUtils.convertHexCodes("#D93747Power"))
                     .setLore(new String[]{
                             StringUtils.convertHexCodes("#CCCCCC" + "Gain base damage per point spent on power."),

--- a/plugin/src/main/java/io/github/math0898/rpgframework/commands/stats/StatsGUI.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/commands/stats/StatsGUI.java
@@ -14,8 +14,9 @@ import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
-import static io.github.math0898.rpgframework.RpgPlayer.DAMAGE_PER_POINT;
-import static io.github.math0898.rpgframework.RpgPlayer.HEALTH_PER_POINT;
+import java.text.NumberFormat;
+
+import static io.github.math0898.rpgframework.RpgPlayer.*;
 
 /**
  * The StatsGUI shows information about a player.
@@ -78,14 +79,29 @@ public class StatsGUI extends AbstractGUI {
                         ChatColor.AQUA + "Current Level: " + target.getLevel() + " (" + target.getExperience() + ")",
                         StringUtils.convertHexCodes("#F2D951Gear Score: " + target.getGearScore())
                 }).build());
-
+        // todo: Ascending costs?
         if (viewer.getUniqueId() == target.getUuid()) {
             inv.setItem(29, new ItemBuilder(Material.IRON_CHESTPLATE).setDisplayName(StringUtils.convertHexCodes("#F454DATenacity"))
                     .setLore(new String[]{
                             StringUtils.convertHexCodes("#CCCCCC" + "Gain health per point spent on tenacity."),
                             StringUtils.convertHexCodes("#CCCCCC" + "Current Bonus:#F454DA +" + target.getHealthTalentPoints() * HEALTH_PER_POINT),
                             StringUtils.convertHexCodes("#CCCCCC" + "Available Points: " + ChatColor.DARK_AQUA + target.getPointsUnallocated())
-                    }).build()); // todo: Ascending costs?
+                    }).build());
+            inv.setItem(30, new ItemBuilder(Material.FEATHER).setDisplayName(ChatColor.AQUA + "Swiftness")
+                    .setLore(new String[]{
+                            StringUtils.convertHexCodes("#CCCCCC" + "Gain movement speed per point spent on swiftness."),
+                            StringUtils.convertHexCodes("#CCCCCC" + "Current Bonus:" + ChatColor.AQUA + " +" + String.format("%.1f", target.getMovementSpeedTalentPoints() * MOVEMENT_SPEED_PER_POINT * 100)),
+                            StringUtils.convertHexCodes("#CCCCCC" + "Spent Points: " + ChatColor.DARK_AQUA + target.getMovementSpeedTalentPoints() + " / " + MOVEMENT_SPEED_MAX_POINTS),
+                            StringUtils.convertHexCodes("#CCCCCC" + "Available Points: " + ChatColor.DARK_AQUA + target.getPointsUnallocated())
+                    }).build());
+            inv.setItem(32, new ItemBuilder(Material.WOODEN_SWORD).setDisplayName(ChatColor.YELLOW + "Weak Point Targeting")
+                    .setLore(new String[]{
+                            StringUtils.convertHexCodes("#CCCCCC" + "Gain critical strike chance per point spent on"),
+                            StringUtils.convertHexCodes("#CCCCCC" + "weak point targeting."),
+                            StringUtils.convertHexCodes("#CCCCCC" + "Current Bonus: " + ChatColor.YELLOW + String.format("%.1f", (target.getCritChanceTalentPoints() * CRIT_CHANCE_PER_POINT) * 100) + "%"),
+                            StringUtils.convertHexCodes("#CCCCCC" + "Spent Points: " + ChatColor.DARK_AQUA + target.getCritChanceTalentPoints() + " / " + CRIT_CHANCE_MAX_POINTS),
+                            StringUtils.convertHexCodes("#CCCCCC" + "Available Points: " + ChatColor.DARK_AQUA + target.getPointsUnallocated())
+                    }).build());
             inv.setItem(33, new ItemBuilder(Material.IRON_SWORD).setDisplayName(StringUtils.convertHexCodes("#D93747Power"))
                     .setLore(new String[]{
                             StringUtils.convertHexCodes("#CCCCCC" + "Gain base damage per point spent on power."),
@@ -94,7 +110,7 @@ public class StatsGUI extends AbstractGUI {
                     }).build());
             inv.setItem(40, new ItemBuilder(Material.BARRIER).setDisplayName(ChatColor.RED + "Reset Points")
                     .setLore(new String[]{
-                            StringUtils.convertHexCodes("#CCCCCC" + "You will gain " + ChatColor.DARK_AQUA + target.getPointsUnallocated() + "#CCCCCC points.")
+                            StringUtils.convertHexCodes("#CCCCCC" + "You will gain " + ChatColor.DARK_AQUA + target.getLevel() + "#CCCCCC points.")
                     }).build());
         }
     }
@@ -114,6 +130,8 @@ public class StatsGUI extends AbstractGUI {
             if (rpgPlayer == null) return;
             switch (event.getSlot()) { // todo: These should be inactive if player is not the player who's stats are showing.
                 case 29 -> rpgPlayer.allocatePoint("health");
+                case 30 -> rpgPlayer.allocatePoint("movement_speed");
+                case 32 -> rpgPlayer.allocatePoint("critical_chance");
                 case 33 -> rpgPlayer.allocatePoint("damage");
                 case 40 -> rpgPlayer.resetPoints();
             }

--- a/plugin/src/main/java/io/github/math0898/rpgframework/commands/stats/StatsGUI.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/commands/stats/StatsGUI.java
@@ -2,6 +2,7 @@ package io.github.math0898.rpgframework.commands.stats;
 
 import io.github.math0898.rpgframework.PlayerManager;
 import io.github.math0898.rpgframework.RpgPlayer;
+import io.github.math0898.utils.StringUtils;
 import io.github.math0898.utils.gui.AbstractGUI;
 import io.github.math0898.utils.items.ItemBuilder;
 import net.md_5.bungee.api.ChatColor;
@@ -12,6 +13,9 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+
+import static io.github.math0898.rpgframework.RpgPlayer.DAMAGE_PER_POINT;
+import static io.github.math0898.rpgframework.RpgPlayer.HEALTH_PER_POINT;
 
 /**
  * The StatsGUI shows information about a player.
@@ -68,16 +72,29 @@ public class StatsGUI extends AbstractGUI {
                 .setOwningPlayer(target.getUuid())
                 .setDisplayName(target.getPlayerRarity() + target.getName())
                 .setLore(new String[] { // todo: Make these colors match item colors.
-                        ChatColor.RED + "Health: " + (long) (target.getCurrentHealth() * 5.0) + " / " + (long) (target.getMaxHealth() * 5.0),
-                        ChatColor.DARK_GREEN + "Class: " + target.getCombatClass().getFormattedName(),
+                        StringUtils.convertHexCodes("#F454DAHealth: " + (long) (target.getCurrentHealth() * 5.0) + " / " + (long) (target.getMaxHealth() * 5.0)),
+                        StringUtils.convertHexCodes("#CCCCCCClass: " + target.getCombatClass().getFormattedName()),
                         ChatColor.AQUA + "Current Level: " + target.getLevel() + " (" + target.getExperience() + ")",
-                        ChatColor.YELLOW + "Gear Score: " + target.getGearScore()
+                        StringUtils.convertHexCodes("#F2D951Gear Score: " + target.getGearScore())
                 }).build());
 
         if (viewer.getUniqueId() == target.getUuid()) {
-            inv.setItem(29, new ItemBuilder(Material.IRON_CHESTPLATE).setDisplayName("Increase Health").build());
-            inv.setItem(33, new ItemBuilder(Material.IRON_SWORD).setDisplayName("Increase Damage").build());
-            inv.setItem(40, new ItemBuilder(Material.BARRIER).setDisplayName("Reset Points").build());
+            inv.setItem(29, new ItemBuilder(Material.IRON_CHESTPLATE).setDisplayName(StringUtils.convertHexCodes("#F454DATenacity"))
+                    .setLore(new String[]{
+                            StringUtils.convertHexCodes("#CCCCCC" + "Gain health per point spent on tenacity."),
+                            StringUtils.convertHexCodes("#CCCCCC" + "Current Bonus:#F454DA +" + target.getHealthTalentPoints() * HEALTH_PER_POINT),
+                            StringUtils.convertHexCodes("#CCCCCC" + "Available Points: " + ChatColor.DARK_AQUA + target.getPointsUnallocated())
+                    }).build());
+            inv.setItem(33, new ItemBuilder(Material.IRON_SWORD).setDisplayName(StringUtils.convertHexCodes("#D93747Power"))
+                    .setLore(new String[]{
+                            StringUtils.convertHexCodes("#CCCCCC" + "Gain base damage per point spent on power."),
+                            StringUtils.convertHexCodes("#CCCCCC" + "Current Bonus:#D93747 +" + target.getDamageTalentPoints() * DAMAGE_PER_POINT),
+                            StringUtils.convertHexCodes("#CCCCCC" + "Available Points: " + ChatColor.DARK_AQUA + target.getPointsUnallocated())
+                    }).build());
+            inv.setItem(40, new ItemBuilder(Material.BARRIER).setDisplayName(ChatColor.RED + "Reset Points")
+                    .setLore(new String[]{
+                            StringUtils.convertHexCodes("#CCCCCC" + "You will gain " + ChatColor.DARK_AQUA + target.getPointsUnallocated() + "#CCCCCC points.")
+                    }).build());
         }
     }
 

--- a/plugin/src/main/java/io/github/math0898/rpgframework/items/editor/EditorGUI.java
+++ b/plugin/src/main/java/io/github/math0898/rpgframework/items/editor/EditorGUI.java
@@ -3,7 +3,7 @@ package io.github.math0898.rpgframework.items.editor;
 import io.github.math0898.rpgframework.Rarity;
 import io.github.math0898.rpgframework.items.EquipmentSlots;
 import io.github.math0898.utils.Utils;
-import io.github.math0898.utils.gui.GUI;
+import io.github.math0898.utils.gui.AbstractGUI;
 import io.github.math0898.utils.gui.GUIManager;
 import io.github.math0898.utils.items.ItemBuilder;
 import org.bukkit.Bukkit;
@@ -32,7 +32,7 @@ import java.util.stream.Stream;
  *
  * @author Sugaku
  */
-public class EditorGUI implements GUI, Listener { // todo: Tag player submission, non-admin stats on rarity.
+public class EditorGUI extends AbstractGUI implements Listener { // todo: Tag player submission, non-admin stats on rarity.
 // todo: Prevent spamming abuse.
     /**
      * A map of ItemConstructs organized by the opening player.
@@ -75,6 +75,17 @@ public class EditorGUI implements GUI, Listener { // todo: Tag player submission
         Inventory inv = Bukkit.createInventory(player, 54, getTitle());
         buildInventory(player, inv);
         player.openInventory(inv);
+    }
+
+    /**
+     * Opens this GUI to the given player.
+     *
+     * @param player The player to open the GUI to.
+     * @param params Any parameters to add to the inventory when to open.
+     */
+    @Override
+    public void openInventory (Player player, String... params) {
+        openInventory(player);
     }
 
     /**

--- a/plugin/src/main/java/io/github/math0898/utils/commands/BetterCommand.java
+++ b/plugin/src/main/java/io/github/math0898/utils/commands/BetterCommand.java
@@ -6,6 +6,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.*;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 
@@ -163,7 +164,7 @@ public abstract class BetterCommand implements CommandExecutor, TabCompleter { /
      * @param message    The message to send.
      * @param sendPrefix Whether a prefix should be sent with this message or not.
      */
-    protected void send(CommandSender user, String message, boolean sendPrefix) {
+    protected void send (CommandSender user, String message, boolean sendPrefix) {
         if (sendPrefix) user.sendMessage(prefix + message);
         else user.sendMessage(ChatColor.GRAY + message);
     }
@@ -185,6 +186,17 @@ public abstract class BetterCommand implements CommandExecutor, TabCompleter { /
                 send(sender, ChatColor.RED + "Is " + args[index] + " a number? Defaulting to 1.");
             }
         }
+        return toReturn;
+    }
+
+    /**
+     * A utility method to get the currently online player's as a list of strings.
+     *
+     * @return The current online players as a List<String>.
+     */
+    protected List<String> getPlayerList () {
+        List<String> toReturn = new ArrayList<>();
+        Bukkit.getOnlinePlayers().forEach((p) -> toReturn.add(p.getName()));
         return toReturn;
     }
 }

--- a/plugin/src/main/java/io/github/math0898/utils/commands/BetterCommand.java
+++ b/plugin/src/main/java/io/github/math0898/utils/commands/BetterCommand.java
@@ -179,7 +179,7 @@ public abstract class BetterCommand implements CommandExecutor, TabCompleter { /
      */
     protected int getIntegerParam (int index, String[] args, CommandSender sender) {
         int toReturn = 1;
-        if (args.length == index + 1) {
+        if (index < args.length) {
             try {
                 toReturn = Integer.parseInt(args[index]);
             } catch (Exception e) {

--- a/plugin/src/main/java/io/github/math0898/utils/gui/AbstractGUI.java
+++ b/plugin/src/main/java/io/github/math0898/utils/gui/AbstractGUI.java
@@ -1,0 +1,23 @@
+package io.github.math0898.utils.gui;
+
+import org.bukkit.entity.Player;
+
+/**
+ * Provides a baseline GUI with some dummy implementations to make extensions easier.
+ *
+ * @author Sugaku
+ */
+public abstract class AbstractGUI implements GUI {
+
+    /**
+     * Opens this GUI to the given player. {@link AbstractGUI} provides a dummy implementation that calls
+     * {@link #openInventory(Player)}.
+     *
+     * @param player The player to open the GUI to.
+     * @param params Any parameters to pass onto the GUI when opening.
+     */
+    @Override
+    public void openInventory (Player player, String... params) {
+        openInventory(player);
+    }
+}

--- a/plugin/src/main/java/io/github/math0898/utils/gui/GUI.java
+++ b/plugin/src/main/java/io/github/math0898/utils/gui/GUI.java
@@ -19,6 +19,14 @@ public interface GUI {
     void openInventory (Player player);
 
     /**
+     * Opens this GUI to the given player.
+     *
+     * @param player The player to open the GUI to.
+     * @param params Any parameters to add to the inventory when to open.
+     */
+    void openInventory (Player player, String... params);
+
+    /**
      * Called whenever this GUI is clicked.
      *
      * @param event The inventory click event.

--- a/plugin/src/main/java/io/github/math0898/utils/gui/GUIManager.java
+++ b/plugin/src/main/java/io/github/math0898/utils/gui/GUIManager.java
@@ -82,6 +82,19 @@ public class GUIManager implements Listener {
     }
 
     /**
+     * Opens the GUI by the given id to the given player.
+     *
+     * @param id     The id of the GUI to open.
+     * @param player The player to open the GUI to.
+     * @param params Any parameters to pass to the GUI.
+     */
+    public void openGUI (String id, Player player, String... params) {
+        GUI gui = guisByID.get(id);
+        if (gui == null) Utils.console("Tried to open: " + id + " but GUI not found!", Level.WARNING);
+        else gui.openInventory(player, params);
+    }
+
+    /**
      * Called whenever an inventory is clicked.
      *
      * @param event The inventory click event to consider.

--- a/plugin/src/main/java/io/github/math0898/utils/gui/PageableGUI.java
+++ b/plugin/src/main/java/io/github/math0898/utils/gui/PageableGUI.java
@@ -15,7 +15,7 @@ import org.bukkit.inventory.ItemStack;
  *
  * @author Sugaku
  */
-public abstract class PageableGUI implements GUI {
+public abstract class PageableGUI extends AbstractGUI {
 
     /**
      * An array of items that are in the pages of this PageableGUI.

--- a/plugin/src/main/java/sugaku/rpg/framework/items/ItemsManager.java
+++ b/plugin/src/main/java/sugaku/rpg/framework/items/ItemsManager.java
@@ -1,14 +1,12 @@
 package sugaku.rpg.framework.items;
 
 import io.github.math0898.rpgframework.items.ItemManager;
-import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.inventory.meta.LeatherArmorMeta;
 
 import java.util.*;
 
@@ -73,46 +71,6 @@ public final class ItemsManager {
             case LEATHER_HELMET,  IRON_HELMET,  CHAINMAIL_HELMET,  GOLDEN_HELMET,  DIAMOND_HELMET,  NETHERITE_HELMET -> itemId += "Helmet";
         }
         return ItemManager.getInstance().getItem(itemId);
-    }
-
-    /**
-     * Returns the String name that should be used for the given item. This is a helper method.
-     */
-    public static String genName(char[] name) {
-
-        StringBuilder r = new StringBuilder();
-
-        for (int i = 0; i < name.length; i++) {
-            if (name[i] == '_') r.append(' ');
-            else if (i == 0) r.append(Character.toUpperCase(name[i]));
-            else if (name[i - 1] == '_') r.append(Character.toUpperCase(name[i]));
-            else r.append(name[i]);
-        }
-
-        return r.toString();
-    }
-
-    /**
-     * Takes the given string and increases the rarity of the name. Checks to see if it should be increased too.
-     * @param s The name to be upgraded.
-     * @return The upgraded name.
-     */
-    public static String increaseRarity(String s) {
-
-        if (s.contains("§k")) return s;
-
-        String r = s;
-
-        r = s.replace("§d", "§c§k-§r§c ");
-        r = s.replace("§6", "§d§k-§r§d ");
-        r = s.replace("§9", "§6§k-§r§6 ");
-        r = s.replace("§a", "§9§k-§r§9 ");
-
-        if (r.equals(s)) r = "§a§k-§r§a " + s;
-
-        r += " §" + r.toCharArray()[1] +"§k-";
-
-        return r;
     }
 
     /**
@@ -189,48 +147,5 @@ public final class ItemsManager {
         meta.setUnbreakable(true);
         r.setItemMeta(meta);
         return r;
-    }
-
-    /**
-     * Creates a custom item of the given material, name, lore, and array of attribute modifiers. Used to create items
-     * in line. This method can significantly reduce scope.
-     *
-     * @param m The material for the item.
-     * @param i The number of items in the stack.
-     * @param n The name of the item.
-     * @param lines The lines of lore.
-     * @param attributes The attributes to be added to the item.
-     */
-    @Deprecated
-    public static ItemStack createItem(Material m, int i, String n, String[] lines, AttributeModifier[] attributes) {
-        ItemStack item = createItem(m, i, n, lines);
-        ItemMeta meta = item.getItemMeta();
-        assert meta != null;
-        // TODO: This is very specific to make RPG compile and run successfully.
-        for (int j = 0; j < attributes.length; j++) {
-            meta.addAttributeModifier(j == 0 ? Attribute.GENERIC_ATTACK_DAMAGE : Attribute.GENERIC_MOVEMENT_SPEED, attributes[j]);
-        }
-        item.setItemMeta(meta);
-        return item;
-    }
-
-    /**
-     * Creates a leather armor item with the given dyes. It's implied that each item stack will only have one item.
-     *
-     * @param m The material for the item.
-     * @param n The name of the item.
-     * @param lines The lines of lore.
-     * @param r The red of the dye.
-     * @param g The green of the dye.
-     * @param b The blue of the dye.
-     */
-    public static ItemStack createLeatherArmor(Material m, String n, String[] lines, int r, int g, int b) {
-        if (m != Material.LEATHER_BOOTS && m != Material.LEATHER_LEGGINGS && m != Material.LEATHER_CHESTPLATE && m != Material.LEATHER_HELMET) return null;
-        ItemStack item = createItem(m, 1, n, lines);
-        LeatherArmorMeta meta = (LeatherArmorMeta) item.getItemMeta();
-        assert meta != null;
-        meta.setColor(Color.fromRGB(r, g, b));
-        item.setItemMeta(meta);
-        return item;
     }
 }

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: RPGFramework
 version: 2.1.1
 main: io.github.math0898.rpgframework.RPGFramework
 api-version: 1.21
-authors: [ Sugaku ]
+authors: [ Sugaku, Cybellereaper ]
 description: The main framework plugin used for all of Math0898/Sugaku's RPG plugins.
 prefix: RPG Framework
 load: POSTWORLD

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -49,3 +49,6 @@ commands:
   artifact:
     description: "Command for accessing a player's artifact collection."
     permission: "rpg.artifact"
+  stats:
+    description: "Displays stats for the player running the command as well as other players."
+    permission: "rpg.stats"

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -52,3 +52,6 @@ commands:
   stats:
     description: "Displays stats for the player running the command as well as other players."
     permission: "rpg.stats"
+  rpg-dungo:
+    description: "Exports a region of space into a YAML format for use in dungeons."
+    permissions: "rpg.admin"

--- a/plugin/src/main/resources/tilesets/TestTileset.yml
+++ b/plugin/src/main/resources/tilesets/TestTileset.yml
@@ -1,4 +1,4 @@
-starting-room:
+starting-room2:
   footprint:
     corner1:
       x: 2
@@ -34,3 +34,165 @@ starting-room:
         x: 0
         y: -1
         z: -1
+
+starting-room:
+  footprint:
+    corner1:
+      x: 2
+      z: 1
+    corner2:
+      x: -2
+      z: -1
+  doors:
+    1:
+      x: 2
+      y: 1
+      z: 0
+  blocks:
+    BLACK_WOOL:
+      0:
+        x: 0
+        y: 0
+        z: 0
+      2:
+        x: 0
+        y: 0
+        z: 2
+      4:
+        x: 0
+        y: 0
+        z: 4
+      6:
+        x: 0
+        y: 0
+        z: 6
+      8:
+        x: 1
+        y: 0
+        z: 1
+      10:
+        x: 1
+        y: 0
+        z: 3
+      12:
+        x: 1
+        y: 0
+        z: 5
+      14:
+        x: 2
+        y: 0
+        z: 0
+      16:
+        x: 2
+        y: 0
+        z: 4
+      18:
+        x: 2
+        y: 0
+        z: 6
+      20:
+        x: 3
+        y: 0
+        z: 5
+      23:
+        x: 4
+        y: 0
+        z: 4
+      25:
+        x: 4
+        y: 0
+        z: 6
+      28:
+        x: 5
+        y: 0
+        z: 5
+      30:
+        x: 6
+        y: 0
+        z: 0
+      33:
+        x: 6
+        y: 0
+        z: 4
+      35:
+        x: 6
+        y: 0
+        z: 6
+    LIGHT_BLUE_WOOL:
+      1:
+        x: 0
+        y: 0
+        z: 1
+      3:
+        x: 0
+        y: 0
+        z: 3
+      5:
+        x: 0
+        y: 0
+        z: 5
+      7:
+        x: 1
+        y: 0
+        z: 0
+      9:
+        x: 1
+        y: 0
+        z: 2
+      11:
+        x: 1
+        y: 0
+        z: 4
+      13:
+        x: 1
+        y: 0
+        z: 6
+      15:
+        x: 2
+        y: 0
+        z: 3
+      17:
+        x: 2
+        y: 0
+        z: 5
+      19:
+        x: 3
+        y: 0
+        z: 4
+      21:
+        x: 3
+        y: 0
+        z: 6
+      24:
+        x: 4
+        y: 0
+        z: 5
+      26:
+        x: 5
+        y: 0
+        z: 0
+      27:
+        x: 5
+        y: 0
+        z: 4
+      29:
+        x: 5
+        y: 0
+        z: 6
+      31:
+        x: 6
+        y: 0
+        z: 1
+      32:
+        x: 6
+        y: 0
+        z: 3
+      34:
+        x: 6
+        y: 0
+        z: 5
+    WHITE_WOOL:
+      22:
+        x: 4
+        y: 0
+        z: 1


### PR DESCRIPTION
Adds `/stats` menu to the plugin as long as players have the permission `rpg.stats`. Additionally functions as a talent selector, coming with 4 basic talents: movement speed, attack damage, health, and critical strike chance.

Closes 8.